### PR TITLE
Update :search_fields to class_attribute instead of cattr_accessor

### DIFF
--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -2,7 +2,7 @@ module Mongoid::Search
   extend ActiveSupport::Concern
 
   included do
-    cattr_accessor :search_fields
+    class_attribute :search_fields
     @@classes ||= []
     @@classes << self
   end
@@ -15,7 +15,7 @@ module Mongoid::Search
     # Set a field or a number of fields as sources for search
     def search_in(*args)
       args, options = args_and_options(args)
-      self.search_fields = (self.search_fields || []).concat args
+      self.search_fields = (self.search_fields || []).clone.concat args
 
       field :_keywords, :type => Array
 

--- a/spec/models/product.rb
+++ b/spec/models/product.rb
@@ -13,3 +13,9 @@ class Product
   search_in :brand, :name, :outlet, :attrs, :tags => :name, :category => [:name, :description],
             :subproducts => [:brand, :name], :info => [ :summary, :description ]
 end
+
+class SubProduct < Product
+  field :sub_product_specific
+
+  search_in :sub_product_specific
+end

--- a/spec/mongoid_search_spec.rb
+++ b/spec/mongoid_search_spec.rb
@@ -270,4 +270,10 @@ describe Mongoid::Search do
       @product._keywords.should include("fahrzeug")
     end
   end
+
+  context "when inherited" do
+    it "should set search fields on a class basis" do
+      expect(Product.search_fields).not_to include(:sub_product_specific)
+    end
+  end
 end


### PR DESCRIPTION
This change is relevant if you use inheritance in your models. With cattr_accessor, sub-classes invocation of search_in will overwrite the base class search_fields. With class_attribtue and cloning the array when setting it, this is avoided.