### PR TITLE
Issue 87

### DIFF
--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -47,52 +47,52 @@ module Mongoid::Search
 
     private
 
-      def query(keywords, options)
-        keywords_hash = keywords.map do |kw|
-          kw = Mongoid::Search.regex.call(kw) if Mongoid::Search.regex_search
-          { :_keywords => kw }
-        end
-
-        criteria.send("#{(options[:match]).to_s}_of", *keywords_hash)
+    def query(keywords, options)
+      keywords_hash = keywords.map do |kw|
+        kw = Mongoid::Search.regex.call(kw) if Mongoid::Search.regex_search
+        { :_keywords => kw }
       end
 
-      def args_and_options(args)
-        options = args.last.is_a?(Hash) &&
-                  [:match,
-                   :allow_empty_search,
-                   :relevant_search].include?(args.last.keys.first) ? args.pop : {}
+      criteria.send("#{(options[:match]).to_s}_of", *keywords_hash)
+    end
+
+    def args_and_options(args)
+      options = args.last.is_a?(Hash) &&
+        [:match,
+         :allow_empty_search,
+         :relevant_search].include?(args.last.keys.first) ? args.pop : {}
 
         [args, extract_options(options)]
-      end
+    end
 
-      def extract_options(options)
-        {
-          :match              => options[:match]              || Mongoid::Search.match,
-          :allow_empty_search => options[:allow_empty_search] || Mongoid::Search.allow_empty_search,
-          :relevant_search    => options[:relevant_search]    || Mongoid::Search.relevant_search
-        }
-      end
+    def extract_options(options)
+      {
+        :match              => options[:match]              || Mongoid::Search.match,
+        :allow_empty_search => options[:allow_empty_search] || Mongoid::Search.allow_empty_search,
+        :relevant_search    => options[:relevant_search]    || Mongoid::Search.relevant_search
+      }
+    end
 
-      def search_without_relevance(query, options)
-        query(Util.normalize_keywords(query), options)
-      end
+    def search_without_relevance(query, options)
+      query(Util.normalize_keywords(query), options)
+    end
 
-      def search_relevant(query, options)
-        results_with_relevance(query, options).sort { |o| o['value'] }.map do |r|
+    def search_relevant(query, options)
+      results_with_relevance(query, options).sort { |o| o['value'] }.map do |r|
 
-          new(r['_id'].merge(:relevance => r['value'])) do |o|
-            # Need to match the actual object
-            o.instance_variable_set('@new_record', false)
-            o._id = r['_id']['_id']
-          end
-
+        new(r['_id'].merge(:relevance => r['value'])) do |o|
+          # Need to match the actual object
+          o.instance_variable_set('@new_record', false)
+          o._id = r['_id']['_id']
         end
+
       end
+    end
 
-      def results_with_relevance(query, options)
-        keywords = Mongoid::Search::Util.normalize_keywords(query)
+    def results_with_relevance(query, options)
+      keywords = Mongoid::Search::Util.normalize_keywords(query)
 
-        map = %Q{
+      map = %Q{
           function() {
             var entries = 0;
             for(i in keywords) {
@@ -106,24 +106,24 @@ module Mongoid::Search
               emit(this, entries);
             }
           }
-        }
+      }
 
-        reduce = %Q{
+      reduce = %Q{
           function(key, values) {
             return(values);
           }
-        }
+      }
 
-        query(keywords, options).map_reduce(map, reduce).scope(:keywords => keywords).out(:inline => 1)
-      end
+      query(keywords, options).map_reduce(map, reduce).scope(:keywords => keywords).out(:inline => 1)
     end
+  end
 
-    def index_keywords!
-      update_attribute(:_keywords, set_keywords)
-    end
+  def index_keywords!
+    update_attribute(:_keywords, set_keywords)
+  end
 
-    def set_keywords
-      self._keywords = Mongoid::Search::Util.keywords(self, self.search_fields).
-        flatten.reject{|k| k.nil? || k.empty?}.uniq.sort
-    end
+  def set_keywords
+    self._keywords = Mongoid::Search::Util.keywords(self, self.search_fields).
+      flatten.reject{|k| k.nil? || k.empty?}.uniq.sort
+  end
 end

--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -26,6 +26,8 @@ module Mongoid::Search
 
     def full_text_search(query, options={})
       options = extract_options(options)
+      attr_accessor :relevance if options[:relevant_search].eql? true
+
       return (options[:allow_empty_search] ? criteria.all : []) if query.blank?
 
       if options[:relevant_search]


### PR DESCRIPTION
- Added ```attr_accessor :relevance``` as mongoid > 4 doesn't support dynamic attributes by default. We need to include module ``` Mongoid::Attributes::Dynamic``` and I think relevance should not be added at database level, as some other search will override value of previous search.

- This also fixes failing test cases of [relevant_search](https://github.com/mauriciozaffari/mongoid_search/blob/master/spec/mongoid_search_spec.rb#L230)