### PR TITLE
Add license flag to the gemspec

### DIFF
--- a/mongoid_search-java.gemspec
+++ b/mongoid_search-java.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.papodenerd.net/mongoid-search-full-text-search-for-your-mongoid-models/"
   s.summary = "Search implementation for Mongoid ORM"
   s.description = "Simple full text search implementation."
+  s.license = 'MIT'
 
   s.required_rubygems_version = ">= 1.3.6"
 

--- a/mongoid_search.gemspec
+++ b/mongoid_search.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.papodenerd.net/mongoid-search-full-text-search-for-your-mongoid-models/"
   s.summary = "Search implementation for Mongoid ORM"
   s.description = "Simple full text search implementation."
+  s.license = 'MIT'
 
   s.required_rubygems_version = ">= 1.3.6"
   


### PR DESCRIPTION
I picked the MIT license, as the LICENSE file looks like MIT.
I would like to add this because it will make automated license checking using [dblock/gem-license](https://github.com/dblock/gem-licenses) easier.