### PR TITLE
Regex char correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Alternatively, you can create an initializer to setup those options:
       config.regex = Proc.new { |query| /#{query}/ }
 
       ## Match partial words on the beginning or in the end (slightly faster)
-      # config.regex = Proc.new { |query| /ˆ#{query}/ }
+      # config.regex = Proc.new { |query| /^#{query}/ }
       # config.regex = Proc.new { |query| /#{query}$/ }
 
       # Ligatures to be replaced

--- a/lib/mongoid_search.rb
+++ b/lib/mongoid_search.rb
@@ -47,7 +47,7 @@ module Mongoid::Search
   @@regex = Proc.new { |query| /#{query}/ }
 
   ## Match partial words on the beginning or in the end (slightly faster)
-  # @@regex = Proc.new { |query| /ˆ#{query}/ }
+  # @@regex = Proc.new { |query| /^#{query}/ }
   # @@regex = Proc.new { |query| /#{query}$/ }
 
   # Ligatures to be replaced


### PR DESCRIPTION
For matching partial words on the beginning readme and config file was using 'ˆ' char instead of '^' fixed this.