### PR TITLE
Changes in Rspec dependency gemspec

### DIFF
--- a/mongoid_search.gemspec
+++ b/mongoid_search.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   
   s.add_dependency("mongoid", [">= 3.0.0"])
   s.add_dependency("fast-stemmer", ["~> 1.0.0"])
-  s.add_development_dependency("database_cleaner", [">= 0.8.0"])
-  s.add_development_dependency("rake", ["~> 0.8.7"])
-  s.add_development_dependency("rspec", ["~> 2.4"])
+  s.add_dependency("database_cleaner", [">= 0.8.0"])
+  s.add_dependency("rake", ["~> 0.8.7"])
+  s.add_dependency("rspec", '>= 2.4', '<= 3.2')
 
   s.require_path = "lib"
   s.files = Dir["lib/**/*", "tasks/*.rake"] + %w(LICENSE README.md Rakefile VERSION)


### PR DESCRIPTION
It's always good to user latest gems and now this library remove all deprecated version and support latest version.